### PR TITLE
Display all users' mute status

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -183,7 +183,7 @@ function DB(config, models) {
       // Update obj with a few properties from newPrefs
       // TODO whenever I add something to the model, I have to add it to 2
       //      additional places in the server. I'd rather add it to ZERO.
-      for (key of ['color', 'requeueVideos', 'selectedPlaylist', 'showChatImages']) {
+      for (key of ['color', 'requeueVideos', 'selectedPlaylist', 'showChatImages', 'allowMuteStatus']) {
         if (newPrefs.hasOwnProperty(key)) {
           obj[key] = newPrefs[key];
         }

--- a/lib/jub.js
+++ b/lib/jub.js
@@ -33,6 +33,7 @@ function JubDJ(config, gapi, chat, db) {
   var usersSeen = new Set();    // for forcing reloads
   var upNext = [];              // keeps track of upcoming videos
   var karmaMap = {};
+  var muteMap = {};
 
   // These will be set by the socketeer
   this.broadcast = function() {};
@@ -380,6 +381,15 @@ function JubDJ(config, gapi, chat, db) {
     return _(jub.karmaMap[user]).values().sum();
   }
 
+  this.muteFor = function(user) {    
+    return jub.muteMap[user];
+  }
+  
+  this.updateMute = function (user, isMuted, callback) {
+    jub.muteMap[user] = isMuted;
+    callback(jub.emittableUserInfo());
+  }
+
   this.getKarma = function(user, callback, errCb) {
     db.getUserKarmaTotal(user, callback, errCb);
   };
@@ -452,7 +462,8 @@ function JubDJ(config, gapi, chat, db) {
       return {
         name: user,
         color: chat.colorFor(user),
-        karma: jub.karmaFor(user)
+        karma: jub.karmaFor(user),
+        isMuted: jub.muteFor(user)
       };
     });
   };
@@ -526,6 +537,7 @@ function JubDJ(config, gapi, chat, db) {
       emittable.requeueVideos = fetched.requeueVideos;
       emittable.selectedPlaylist = fetched.selectedPlaylist;
       emittable.showChatImages = fetched.showChatImages;
+      emittable.allowMuteStatus = fetched.allowMuteStatus;
       callback(emittable);
     }, errCb);
   };
@@ -705,5 +717,6 @@ module.exports = function(config, gapi, chat, db) {
   var jub = new JubDJ(config, gapi, chat, db);
   if (process.env.TEST) { jub.addDj(chat.bot.name); }
   db.getKarmaReceived(jub.setLocalKarmaMapAndRefreshUsers); //load all users' karma into memory
+  jub.muteMap = {};
   return jub;
 };

--- a/lib/models.js
+++ b/lib/models.js
@@ -20,7 +20,9 @@ function basicSchemas(config, auth) {
       // When enabled, add just-finished videos back to the user's queue
       requeueVideos: { type: Boolean, default: false },
       // When enabled, fetches linked images in chat and displays them
-      showChatImages: { type: Boolean, default: false }
+      showChatImages: { type: Boolean, default: false },
+      // When enabled, allows other users to see client's mute status
+      allowMuteStatus: {type: Boolean, default: true }
     },
     Karma: {
       type: String,

--- a/lib/socket-routing.js
+++ b/lib/socket-routing.js
@@ -168,6 +168,12 @@ function Socketeer(jub, chat, config, io) {
       }
     });
 
+    socket.on('mute update', function(user, isMuted) {      
+        jub.updateMute(user, isMuted, function(userList) {
+          emitUsers(userList);
+        });
+    });
+    
     // A user reported presence
     socket.on('user present', function(user) {
       if (user) {

--- a/public/javascripts/global.js
+++ b/public/javascripts/global.js
@@ -28,4 +28,7 @@ socket.on('preferences', function(preferences) {
   if (_.has(preferences, 'showChatImages')) {
     $('#show-chat-images').prop('checked', !!(preferences.showChatImages));
   }
+  if (_.has(preferences, 'allowMuteStatus')) {
+    $('#enable-mute-updates').prop('checked', !!(preferences.allowMuteStatus));
+  }
 });

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -325,6 +325,10 @@ body {
 }
 
 /* current users */
+.jub-mute {
+  width: 5%;
+}
+
 .jub-name {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/views/chat.jade
+++ b/views/chat.jade
@@ -25,6 +25,10 @@ div(id="chat-tab-content", class="tab-content")
           input(class='form-control', id='username-input', placeholder='Username', autocomplete='off')
         input(id='show-chat-images', type='checkbox', action='')
         label(id='show-chat-images-label', for='show-chat-images') Show images from links in chat messages
+        br
+        br
+        input(id='enable-mute-updates', type='checkbox', action='')
+        label(id='enable-mute-updates-label', for='enable-mute-updates') Allow other jubs to see your mute status
 
 include ./username.jade
 
@@ -54,19 +58,40 @@ script.
         'color': user.color,
       });
 
+      var jubMuteTd = $('<td>').addClass('jub-mute');
+      var muteIcon = $('<span>').addClass('user-mute-icon');
+      muteIcon.attr({
+          class: 'glyphicon glyphicon-volume-off',          
+        });
+      if(user.isMuted) 
+        muteIcon.css('visibility', 'visible');
+      else 
+        muteIcon.css('visibility', 'hidden');
+      jubMuteTd.append(muteIcon);
+      
       var jubNameTd = $('<td>').addClass('jub-name');
       jubNameTd.text(user.name);
 
       var jubKarmaTd = $('<td>').addClass('jub-karma');
       jubKarmaTd.text(user.karma + " karma");
 
+      tr.append(jubMuteTd);
       tr.append(jubNameTd);
       tr.append(jubKarmaTd);
 
       $("#jubbin-list-tbody").prepend(tr);
     }
   }
-
+  
+  $('#enable-mute-updates').on('change', function(e) {
+    var data = { allowMuteStatus: this.checked };
+    if(!this.checked)
+      socket.emit('mute update', getUsername(), false);
+    else
+      socket.emit('mute update', getUsername(), player.isMuted());
+    socket.emit('update user preferences', getUsername(), data);
+  })
+  
   $('#chat-navtabs a').click(function (e) {
     // Show it now so that we can do some polishing on the revealed element
     e.preventDefault();

--- a/views/player.jade
+++ b/views/player.jade
@@ -147,6 +147,8 @@ script.
     var newVolume = newState ?  0 : getCookie('volume') || DEFAULT_VOLUME;
     setMute(newState);
     setVolumeSlider(newVolume);
+    if($('#enable-mute-updates').is(":checked"))
+      socket.emit('mute update', getUsername(), newState);
   }
 
   // callback for volume range slider
@@ -167,6 +169,8 @@ script.
 
     refreshSizes(true);
     socket.emit('video state');
+    if($('#enable-mute-updates').is(":checked"))
+      socket.emit('mute update', getUsername(), isMuted);
   }
 
   // The API calls this function when the player's state changes.


### PR DESCRIPTION
Permits individual jubs to allow or disallow broadcasting their mute status to other jubs. This is stored as a user preference.