### PR TITLE
Display clipped track times in chat

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -249,8 +249,14 @@ function Bot(config, gapi, twitter, urban, imitater) {
     if (videoObj.title) {
       let msg = videoObj.user + ' started ' +
                 '"' + videoObj.title + '"';
-      if (_.has(videoObj, 'duration')) {
-        msg += ' (' + jub_util.formatTime(videoObj.duration/1000) + ')';
+      if (typeof videoObj.duration === 'number') {
+        if ((typeof videoObj.clipStartTime === 'number') && (typeof videoObj.clipEndTime === 'number') && 
+            (videoObj.clipEndTime - videoObj.clipStartTime) < videoObj.duration) {
+          msg += ' (✂ ' + jub_util.formatTime((videoObj.clipEndTime - videoObj.clipStartTime)/1000) + ')';
+        }
+        else {
+          msg += ' (' + jub_util.formatTime(videoObj.duration/1000) + ')';
+        }
       }
       callback(botMsgObj(msg));
     }


### PR DESCRIPTION
If a track is clipped, display the clipped time (and indicate with a
scissors icon)